### PR TITLE
Fix argument test suite

### DIFF
--- a/test/arg_suite.go
+++ b/test/arg_suite.go
@@ -100,7 +100,7 @@ func (t *ArgumentTest) Test(c *check.C, cmdName string) {
 		c.Fatal("Name is required")
 	}
 	cmd, err := command.New(cmdName, t.Argument)
-	if err == nil {
+	if t.ExpectedErr == nil {
 		t.assertNoError(c, err)
 	} else {
 		t.assertError(c, err)

--- a/test/arg_suite_test.go
+++ b/test/arg_suite_test.go
@@ -111,6 +111,21 @@ func (s *TestRunnerWithConfig) TestArgumentTestEmptyName(c *check.C) {
 	c.Assert(res.Passed(), check.Equals, false)
 }
 
+// TestArgumentTestErrButReturnOK tests the ArgumentTest with an error but ArgumentTest returns no error.
+func (s *TestRunnerWithConfig) TestArgumentTestErrButReturnOK(c *check.C) {
+	err := errors.New("test error")
+	cat := CustomArgumentTest{
+		name:           "TestArgumentTestErrButReturnOK",
+		argErr:         nil, // no error
+		expectedErr:    err, // expected error
+		expectedErrMsg: "test error",
+	}
+	res := check.Run(&cat, s.cfg)
+	out := strings.ReplaceAll(s.out.String(), "\n", "")
+	c.Assert(out, check.Matches, ".*FAIL:.*CustomArgumentTest\\.Test.*test error.*")
+	c.Assert(res.Passed(), check.Equals, false)
+}
+
 // TestArgumentTestErr tests the ArgumentTest with an error.
 func (s *TestRunnerWithConfig) TestArgumentTestErr(c *check.C) {
 	err := errors.New("test error")


### PR DESCRIPTION
This PR fixes a bug when we test a flag and expect it to return an error, but it returns *no error*, then the test should fail and not pass successfully.