### PR TITLE
Enable option with empty argument

### DIFF
--- a/command/arg_test.go
+++ b/command/arg_test.go
@@ -45,6 +45,11 @@ func TestArguments(t *testing.T) { check.TestingT(t) }
 
 var _ = check.Suite(&test.ArgumentSuite{Cmd: "cmd", Arguments: []test.ArgumentTest{
 	{
+		Name:        "NewArguments with NoopArgument",
+		Argument:    command.NewNoopArgument(),
+		ExpectedCLI: []string{"cmd"},
+	},
+	{
 		Name:        "NewErrorArgument without error",
 		Argument:    command.NewErrorArgument(nil),
 		ExpectedCLI: []string{"cmd"},

--- a/command/option_arg.go
+++ b/command/option_arg.go
@@ -41,8 +41,6 @@ func (o optionArg) Apply(cmd safecli.CommandAppender) error {
 func newOptionArg(name, arg string, isArgRedacted bool) Applier {
 	if err := validateOptionName(name); err != nil {
 		return err
-	} else if arg == "" {
-		return noopArgument{}
 	}
 	return optionArg{
 		name:       name,

--- a/command/option_arg_test.go
+++ b/command/option_arg_test.go
@@ -43,7 +43,7 @@ var _ = check.Suite(&test.ArgumentSuite{Cmd: "cmd", Arguments: []test.ArgumentTe
 	{
 		Name:        "NewOptionWithArgument with empty argument",
 		Argument:    command.NewOptionWithArgument("--option", ""),
-		ExpectedCLI: []string{"cmd"},
+		ExpectedCLI: []string{"cmd", "--option="},
 	},
 
 	{
@@ -65,6 +65,7 @@ var _ = check.Suite(&test.ArgumentSuite{Cmd: "cmd", Arguments: []test.ArgumentTe
 	{
 		Name:        "NewOptionWithRedactedArgument with empty argument",
 		Argument:    command.NewOptionWithRedactedArgument("--option", ""),
-		ExpectedCLI: []string{"cmd"},
+		ExpectedCLI: []string{"cmd", "--option="},
+		ExpectedLog: "cmd --option=<****>",
 	},
 }})


### PR DESCRIPTION
This PR will allow for passing an empty argument to the option and will delegate the logic for managing the empty argument to the user side. See the full discussion [here](https://github.com/kanisterio/kanister/pull/2654#discussion_r1496550554).

Now, we can call `command.NewOptionWithArgument("--opt", "")`, and it will generate `--opt=`, which is a legitimate case. The previous implementation skipped generating `--opt` if argument was an empty string (`""`). 

This logic has now been transferred to the user side for handling empty arguments.

```go
// OptWithArg("") => --opt=
// OptWithArg("custom") => --opt=custom
func OptWithArg(arg string) command.Applier {
	return command.NewOptionWithArgument("--opt", arg)
}

// OptWithOptionalArgAndDefault("") => --opt=default
// OptWithOptionalArgAndDefault("custom") => --opt=custom
func OptWithOptionalArgAndDefault(arg string) command.Applier {
	if arg == "" {
		arg = "default"
	}
	return command.NewOptionWithArgument("--opt", arg)
}

// OptWithOptionalArgAndNoop("") => nothing will be generated
// OptWithOptionalArgAndNoop("custom") => --opt=custom
func OptWithOptionalArgAndNoop(arg string) command.Applier {
	if arg == "" {
		return command.NewNoopArgument()
	}
	return command.NewOptionWithArgument("--opt", arg)
}

// OptWithRequiredArgAndError("") => error
// OptWithRequiredArgAndError("custom") => --opt=custom
func OptWithRequiredArgAndError(arg string) command.Applier {
	if arg == "" {
		return command.NewErrorArgument(fmt.Errorf("arg is required"))
	}
	return command.NewOptionWithArgument("--opt", arg)
}
```