### PR TITLE
Update go to 1.22 and errkit to latest tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,9 @@
 module github.com/kanisterio/safecli
 
-go 1.21.0
-
-toolchain go1.22.4
+go 1.22.7
 
 require (
-	github.com/kanisterio/errkit v0.0.2
+	github.com/kanisterio/errkit v0.0.3
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 )
 

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/kanisterio/errkit v0.0.2 h1:3v3HGz9lHIbZR6Jr9qIJpRjaqUX0rsJSLMEQGsMHiUk=
-github.com/kanisterio/errkit v0.0.2/go.mod h1:ViQ6kPJ2gTJDEvRytmwde7pzG9/sndObF9BPZoEZixc=
+github.com/kanisterio/errkit v0.0.3 h1:1wHaTqV4DZE0XrN+Nq7Q2M8kyKnV8NhhEF3OB7A/Pd8=
+github.com/kanisterio/errkit v0.0.3/go.mod h1:0xesKaif6++1IXFdhb6fywa40J07odjwWq3IKzxWC3A=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=


### PR DESCRIPTION
- Update go to 1.22.7
- Update errkit to latest tag v0.0.3

These two changes will fix some vulnerabilities seen on Snyk scanning.